### PR TITLE
Fix attribute parser.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,5 +14,8 @@
     "purescript-console": "^2.0.0",
     "purescript-quickcheck": "~2.0.0",
     "purescript-string-parsers": "~2.0.0"
+  },
+  "resolutions": {
+    "purescript-lists": "^3.1.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
-  "name": "purescript-html-gen",
-  "version": "1.0.0",
+  "name": "purescript-html-parser",
+  "version": "2.0.0",
   "moduleType": [
     "node"
   ],
@@ -11,8 +11,8 @@
     "output"
   ],
   "dependencies": {
-    "purescript-console": "^1.0.0",
-    "purescript-quickcheck": "~1.0.0",
-    "purescript-string-parsers": "~1.0.1"
+    "purescript-console": "^2.0.0",
+    "purescript-quickcheck": "~2.0.0",
+    "purescript-string-parsers": "~2.0.0"
   }
 }

--- a/src/Text/HTML/Parser/Combinators.purs
+++ b/src/Text/HTML/Parser/Combinators.purs
@@ -4,7 +4,7 @@ import Prelude
 import Control.Alt
 import Control.Apply
 import Data.Char (toCharCode)
-import Data.String (singleton)
+import Data.String (singleton, joinWith)
 import Data.Foldable
 import Data.List (List(..))
 import Data.String.Unsafe as Unsafe
@@ -22,7 +22,7 @@ satisfy :: (Char -> Boolean) -> Parser Char
 satisfy f = try do
   c <- anyChar
   if f c then pure c
-         else fail "Character did not satisfy predicate"
+         else fail $ joinWith "" [ "Character ", (show c),  " did not satisfy predicate" ]
 
 -- | Match the specified character
 char :: Char -> Parser Char

--- a/src/Text/HTML/Parser/Internal.purs
+++ b/src/Text/HTML/Parser/Internal.purs
@@ -66,7 +66,7 @@ parseTextNode :: Parser HTML
 parseTextNode = TextNode <<< catChars <$> many1 (noneOf ['<', '>'])
 
 parseAttributes :: Parser (List Attribute)
-parseAttributes = sepBy parseAttribute skipSpaces
+parseAttributes = sepEndBy parseAttribute skipSpaces
 
 parseAttribute :: Parser Attribute
 parseAttribute = do

--- a/src/Text/HTML/Parser/Internal.purs
+++ b/src/Text/HTML/Parser/Internal.purs
@@ -75,7 +75,9 @@ parseAttribute = do
   maybeEquals <- optionMaybe $ char '='
   value <- case maybeEquals of
     Nothing -> pure ""
-    Just _ -> parseAttributeValue
+    Just _ -> do
+        skipSpaces
+        parseAttributeValue
   pure $ Attribute name value
 
 parseAttributeName :: Parser String
@@ -83,7 +85,7 @@ parseAttributeName = catChars <$> many1 (noneOf [' ', '"', '\'', '>', '/', '='])
 
 parseAttributeValue :: Parser String
 parseAttributeValue = do
-  maybeOpenChar <- optionMaybe $ skipSpaces *> (char '"' <|> char '\'')
+  maybeOpenChar <- optionMaybe (char '"' <|> char '\'')
   case maybeOpenChar of
     Nothing -> catChars <$> many1 (noneOf [' ', '\t', '\n', '\r', '"', '\'', '=', '<', '>', '`', '/'])
     Just openChar -> do

--- a/src/Text/HTML/Parser/Internal.purs
+++ b/src/Text/HTML/Parser/Internal.purs
@@ -85,7 +85,7 @@ parseAttributeValue :: Parser String
 parseAttributeValue = do
   maybeOpenChar <- optionMaybe $ skipSpaces *> (char '"' <|> char '\'')
   case maybeOpenChar of
-    Nothing -> catChars <$> many (noneOf [' ', '>'])
+    Nothing -> catChars <$> many1 (noneOf [' ', '\t', '\n', '\r', '>', '/'])
     Just openChar -> do
       value <- catChars <$> many (noneOf [openChar])
       char openChar

--- a/src/Text/HTML/Parser/Internal.purs
+++ b/src/Text/HTML/Parser/Internal.purs
@@ -85,7 +85,7 @@ parseAttributeValue :: Parser String
 parseAttributeValue = do
   maybeOpenChar <- optionMaybe $ skipSpaces *> (char '"' <|> char '\'')
   case maybeOpenChar of
-    Nothing -> catChars <$> many1 (noneOf [' ', '\t', '\n', '\r', '>', '/'])
+    Nothing -> catChars <$> many1 (noneOf [' ', '\t', '\n', '\r', '"', '\'', '=', '<', '>', '`', '/'])
     Just openChar -> do
       value <- catChars <$> many (noneOf [openChar])
       char openChar

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -79,6 +79,13 @@ main = runTest do
     [ voidElement "br" [Attribute "class" "solid"]
     ]
 
+    -- See if spaces around the equals sign affect attribute parsing if argument value is not
+    --        quoted...
+
+  assertParse """<br class = solid/>"""
+    [ voidElement "br" [Attribute "class" "solid"]
+    ]
+
 assertParse
   :: forall eff f. (Foldable f)
   => String -> f HTML -> Eff (console :: CONSOLE | eff) Unit

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -13,6 +13,7 @@ import Text.HTML.Parser.Array
 
 import Test.Utils
 
+main :: Eff (console :: CONSOLE) Unit
 main = runTest do
   assertParse "<html></html>"
     [ element "html" [] [] ]

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -64,6 +64,21 @@ main = runTest do
       [ voidElement "img" [Attribute "src" "puppies.gif"] ]
     ]
 
+    -- See if whitespace after attributes affect parsing...
+  assertParse """<br class="solid" />"""
+    [ voidElement "br" [Attribute "class" "solid"]
+    ]
+
+    -- See if unquoted attribute value is parsed properly...
+  assertParse """<br class=solid/>"""
+    [ voidElement "br" [Attribute "class" "solid"]
+    ]
+
+    -- See if spaces around the equals sign affect attribute parsing...
+  assertParse """<br class = "solid"/>"""
+    [ voidElement "br" [Attribute "class" "solid"]
+    ]
+
 assertParse
   :: forall eff f. (Foldable f)
   => String -> f HTML -> Eff (console :: CONSOLE | eff) Unit

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -51,11 +51,11 @@ main = runTest do
       ] []
     ]
 
-  assertParse """<div id = 'foo' disabled class =bar"<></div>"""
+  assertParse """<div id = 'foo' disabled class =bar></div>"""
     [ element "div"
       [ Attribute "id" "foo"
       , Attribute "disabled" ""
-      , Attribute "class" """bar"<"""
+      , Attribute "class" """bar"""
       ] []
     ]
 


### PR DESCRIPTION
Hello.

I believe I found and fixed some bugs in attribute parser.

1. It won't handle a whitespace after attributes. (Because `sepBy` will eat the whitespace as a separator and try to parse whatever goes next as another attribute.)
2. It won't handle an unquoted value in the last attribute of a void element. (Because it will consider slash to be part of the value.)

I also made some non-critical changes.

1. Version bumped the library and its dependencies to 2.0.
2. Improved error reporting.
3. Aligned unquoted attribute value parser with HTML5 specification.

Please let me know in what way I should improve my patch for it to be merged.